### PR TITLE
DSNPI-896 bops create new comments endpoint for public planning applications

### DIFF
--- a/engines/bops_api/app/controllers/bops_api/v2/public/comments_public_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/comments_public_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module V2
+    module Public
+      class CommentsPublicController < PublicController
+        def index
+          @planning_application = find_planning_application params[:planning_application_id]
+          @consultation = @planning_application.consultation
+          if @consultation.nil?
+            raise BopsApi::Errors::InvalidRequestError, "Consultation not found"
+          end
+          @neighbour_responses = @consultation.neighbour_responses.redacted
+
+          @pagy, @comments = BopsApi::CommentsPublicService.new(
+            @neighbour_responses,
+            pagination_params
+          ).call
+
+          @total_responses = @neighbour_responses.count
+          @response_summary = @neighbour_responses.group(:summary_tag).count
+          @response_summary = {
+            supportive: @response_summary["supportive"] || 0,
+            objection: @response_summary["objection"] || 0,
+            neutral: @response_summary["neutral"] || 0
+          }
+
+          respond_to do |format|
+            format.json
+          end
+        end
+
+        private
+
+        # Permit and return the required parameters
+        def pagination_params
+          params.permit(:sortBy, :orderBy, :resultsPerPage, :query, :page, :format, :planning_application_id)
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_api/app/controllers/bops_api/v2/public/comments_specialist_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/comments_specialist_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module V2
+    module Public
+      class CommentsSpecialistController < PublicController
+        def index
+          @planning_application = find_planning_application params[:planning_application_id]
+          @consultation = @planning_application.consultation
+          if @consultation.nil?
+            raise BopsApi::Errors::InvalidRequestError, "Consultation not found"
+          end
+          @consultee_responses = @consultation.consultee_responses.redacted
+
+          @total_responses = @consultee_responses.count
+          @total_consulted = @consultation.consultees.count
+
+          @response_summary = @consultee_responses.group(:summary_tag)
+            .unscope(:order) # Remove default ORDER BY clause
+            .count
+          @response_summary = {
+            supportive: @response_summary["approved"] || 0,
+            objection: @response_summary["objected"] || 0,
+            neutral: @response_summary["amendments_needed"] || 0
+          }
+
+          @pagy, @comments = BopsApi::CommentsSpecialistService.new(
+            @consultee_responses,
+            pagination_params
+          ).call
+
+          respond_to do |format|
+            format.json
+          end
+        end
+
+        private
+
+        # Permit and return the required parameters
+        def pagination_params
+          params.permit(:sortBy, :orderBy, :resultsPerPage, :query, :page, :format, :planning_application_id)
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_api/app/services/bops_api/comments_public_service.rb
+++ b/engines/bops_api/app/services/bops_api/comments_public_service.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module BopsApi
+  class CommentsPublicService
+    def initialize(scope, params)
+      @scope = scope
+      @params = params
+    end
+
+    attr_reader :scope, :params
+
+    def call
+      paginate(
+        sort_results(
+          filter_by_query(scope)
+        )
+      )
+    end
+
+    private
+
+    def filter_by_query(scope)
+      if params[:query].present?
+        scope.where("redacted_response ILIKE ?", "%#{params[:query]}%")
+      else
+        scope
+      end
+    end
+
+    def sort_results(scope)
+       # Define allowed fields and their default sort orders
+      allowed_sort_fields = {
+        "receivedAt" => {column: "received_at", default_order: "desc"},
+        "id" => {column: "neighbour_responses.id", default_order: "asc"}
+      }
+
+      # Define allowed orderBy values
+      allowed_order_values = %w[asc desc]
+
+      # Validate sortBy if it is explicitly set
+      if params[:sortBy].present?
+        sort_by = params[:sortBy]&.camelize(:lower)
+        unless allowed_sort_fields.key?(sort_by)
+          raise ArgumentError, "Invalid sortBy field: #{params[:sortBy]}. Allowed fields are: #{allowed_sort_fields.keys.join(", ")}"
+        end
+      else
+        sort_by = "receivedAt" # Default sortBy
+      end
+
+      # Validate orderBy if it is explicitly set
+      if params[:orderBy].present?
+        order_by = params[:orderBy]
+        unless allowed_order_values.include?(order_by)
+          raise ArgumentError, "Invalid orderBy value: #{params[:orderBy]}. Allowed values are: #{allowed_order_values.join(", ")}"
+        end
+      else
+        order_by = allowed_sort_fields[sort_by][:default_order] # Default orderBy
+      end
+
+      # Apply sorting to the scope
+      sort_field = allowed_sort_fields[sort_by]
+      scope.order("#{sort_field[:column]} #{order_by}")
+    end
+
+    def paginate(scope)
+      BopsApi::PostsubmissionPagination.new(scope: scope, params: params).call
+    end
+  end
+end

--- a/engines/bops_api/app/services/bops_api/comments_public_service.rb
+++ b/engines/bops_api/app/services/bops_api/comments_public_service.rb
@@ -59,7 +59,7 @@ module BopsApi
 
       # Apply sorting to the scope
       sort_field = allowed_sort_fields[sort_by]
-      scope.order("#{sort_field[:column]} #{order_by}")
+      scope.reorder("#{sort_field[:column]} #{order_by}")
     end
 
     def paginate(scope)

--- a/engines/bops_api/app/services/bops_api/comments_specialist_service.rb
+++ b/engines/bops_api/app/services/bops_api/comments_specialist_service.rb
@@ -59,7 +59,7 @@ module BopsApi
 
       # Apply sorting to the scope
       sort_field = allowed_sort_fields[sort_by]
-      scope.order("#{sort_field[:column]} #{order_by}")
+      scope.reorder("#{sort_field[:column]} #{order_by}")
     end
 
     def paginate(scope)

--- a/engines/bops_api/app/services/bops_api/comments_specialist_service.rb
+++ b/engines/bops_api/app/services/bops_api/comments_specialist_service.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module BopsApi
+  class CommentsSpecialistService
+    def initialize(scope, params)
+      @scope = scope
+      @params = params
+    end
+
+    attr_reader :scope, :params
+
+    def call
+      paginate(
+        sort_results(
+          filter_by_query(scope)
+        )
+      )
+    end
+
+    private
+
+    def filter_by_query(scope)
+      if params[:query].present?
+        scope.where("redacted_response ILIKE ?", "%#{params[:query]}%")
+      else
+        scope
+      end
+    end
+
+    def sort_results(scope)
+       # Define allowed fields and their default sort orders
+      allowed_sort_fields = {
+        "receivedAt" => {column: "received_at", default_order: "desc"},
+        "id" => {column: "consultee_responses.id", default_order: "asc"}
+      }
+
+      # Define allowed orderBy values
+      allowed_order_values = %w[asc desc]
+
+      # Validate sortBy if it is explicitly set
+      if params[:sortBy].present?
+        sort_by = params[:sortBy]&.camelize(:lower)
+        unless allowed_sort_fields.key?(sort_by)
+          raise ArgumentError, "Invalid sortBy field: #{params[:sortBy]}. Allowed fields are: #{allowed_sort_fields.keys.join(", ")}"
+        end
+      else
+        sort_by = "receivedAt" # Default sortBy
+      end
+
+      # Validate orderBy if it is explicitly set
+      if params[:orderBy].present?
+        order_by = params[:orderBy]
+        unless allowed_order_values.include?(order_by)
+          raise ArgumentError, "Invalid orderBy value: #{params[:orderBy]}. Allowed values are: #{allowed_order_values.join(", ")}"
+        end
+      else
+        order_by = allowed_sort_fields[sort_by][:default_order] # Default orderBy
+      end
+
+      # Apply sorting to the scope
+      sort_field = allowed_sort_fields[sort_by]
+      scope.order("#{sort_field[:column]} #{order_by}")
+    end
+
+    def paginate(scope)
+      BopsApi::PostsubmissionPagination.new(scope: scope, params: params).call
+    end
+  end
+end

--- a/engines/bops_api/app/services/bops_api/postsubmission_pagination.rb
+++ b/engines/bops_api/app/services/bops_api/postsubmission_pagination.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module BopsApi
+  # This class handles pagination for Postsubmission data using the Pagy gem.
+  # It calculates the number of results per page and the current page based on the provided parameters.
+  class PostsubmissionPagination
+    include Pagy::Backend
+
+    DEFAULT_PAGE = 1
+    DEFAULT_MAXRESULTS = 10
+    MAXRESULTS_LIMIT = 50
+
+    # Initializes the pagination service.
+    #
+    # @param scope [ActiveRecord::Relation] The dataset to paginate.
+    # @param params [Hash] The request parameters containing pagination options.
+    def initialize(scope:, params:)
+      @scope = scope
+      @params = params || {}
+    end
+
+    attr_reader :scope, :params
+
+    def call
+      pagy, paginated_scope = pagy(scope, page:, limit: results_per_page, overflow: :last_page)
+      [pagy, paginated_scope]
+    end
+ 
+    private
+
+    def results_per_page
+      value = params[:resultsPerPage].to_i
+      value = DEFAULT_MAXRESULTS if value <= 0
+      [value, MAXRESULTS_LIMIT].min.clamp(1, 1000)
+    end
+
+    def page
+      value = params[:page].to_i
+      value = DEFAULT_PAGE if value <= 0
+      value.clamp(1, 1000)
+    end
+  end
+end

--- a/engines/bops_api/app/services/bops_api/postsubmission_pagination.rb
+++ b/engines/bops_api/app/services/bops_api/postsubmission_pagination.rb
@@ -25,7 +25,7 @@ module BopsApi
       pagy, paginated_scope = pagy(scope, page:, limit: results_per_page, overflow: :last_page)
       [pagy, paginated_scope]
     end
- 
+
     private
 
     def results_per_page

--- a/engines/bops_api/app/views/bops_api/v2/public/comments_public/index.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/comments_public/index.json.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+json.partial! "bops_api/v2/shared/postsubmissionApplication/pagination"
+
+json.summary do
+  json.partial! "bops_api/v2/shared/postsubmissionApplication/comments/comment_public_summary", total_responses: @total_responses, response_summary: @response_summary
+end
+
+json.comments @comments do |comment|
+  json.partial! "bops_api/v2/shared/postsubmissionApplication/comments/comment_public", comment:
+end

--- a/engines/bops_api/app/views/bops_api/v2/public/comments_specialist/index.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/comments_specialist/index.json.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+json.partial! "bops_api/v2/shared/postsubmissionApplication/pagination"
+
+json.summary do
+  json.partial! "bops_api/v2/shared/postsubmissionApplication/comments/comment_specialist_summary", total_responses: @total_responses, total_consulted: @total_consulted, response_summary: @response_summary
+end
+
+json.comments @comments do |comment|
+  json.partial! "bops_api/v2/shared/postsubmissionApplication/comments/comment_specialist", comment:
+end

--- a/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/_pagination.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/_pagination.json.jbuilder
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+json.pagination do
+  json.resultsPerPage @pagy.limit
+  json.currentPage @pagy.page
+  json.totalPages @pagy.pages
+  json.totalItems @pagy.count
+end
+
+# json.links pagy_jsonapi_links(@pagy, absolute: true)

--- a/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/comments/_comment_public.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/comments/_comment_public.json.jbuilder
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# DprComment
+
+json.id comment.id
+json.sentiment comment.summary_tag
+json.comment comment.redacted_response
+json.receivedAt format_postsubmission_datetime(comment.received_at)
+
+# PublicComment
+
+# json.id comment.id
+# json.sentiment comment.summary_tag
+# json.comment comment.redacted_response
+
+# json.author do
+#   json.name do
+#     json.singleLine comment.name
+#   end
+# end
+
+# json.metadata do
+#   json.submittedAt format_postsubmission_datetime(comment.created_at)
+#   json.publishedAt format_postsubmission_datetime(comment.received_at)
+#   json.validAt format_postsubmission_datetime(comment.updated_at)
+# end

--- a/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/comments/_comment_public_summary.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/comments/_comment_public_summary.json.jbuilder
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+json.totalComments total_responses
+if response_summary.present?
+  json.sentiment do
+    json.supportive response_summary[:supportive]
+    json.objection response_summary[:objection]
+    json.neutral response_summary[:neutral]
+  end
+end

--- a/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/comments/_comment_specialist.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/comments/_comment_specialist.json.jbuilder
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# DprComment
+
+json.id comment.id
+json.sentiment case comment.summary_tag
+when "supportive"
+                 "approved"
+when "objected"
+                 "objection"
+when "amendments_needed"
+                 "neutral"
+               else
+                 "neutral" # Fallback for unexpected values
+end
+json.comment comment.redacted_response
+json.receivedAt format_postsubmission_datetime(comment.received_at)
+
+# SpecialistComment
+
+# json.id comment.id
+# json.sentiment comment.summary_tag
+# json.comment comment.redacted_response
+# json.constraints "PlanningConstraint[]"
+# json.reason "string"
+# json.comment "string"
+# json.author "SpecialistCommentAuthor"
+# json.consultedAt "DateTime"
+# json.respondedAt "DateTime"
+# json.files "PostSubmissionFile[]"
+# json.responses "SpecialistComment[]"
+
+# json.author do
+#   json.name do
+#     json.singleLine comment.name
+#   end
+# #   json.organisation "string;"
+# #   json.specialism "string;"
+# #   json.jobTitle "string;"
+# end
+
+# json.metadata do
+#   json.submittedAt format_postsubmission_datetime(comment.created_at)
+#   # json.publishedAt format_postsubmission_datetime(comment.received_at)
+#   json.validAt format_postsubmission_datetime(comment.updated_at)
+# end

--- a/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/comments/_comment_specialist_summary.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/comments/_comment_specialist_summary.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.partial! "bops_api/v2/shared/postsubmissionApplication/comments/comment_public_summary", total_responses: total_responses, response_summary: response_summary
+json.totalConsulted total_consulted

--- a/engines/bops_api/config/routes.rb
+++ b/engines/bops_api/config/routes.rb
@@ -33,6 +33,7 @@ BopsApi::Engine.routes.draw do
         resources :planning_applications, only: [:show] do
           get :search, on: :collection
           resource :documents, only: [:show]
+          get "comments/public", to: "comments_public#index"
         end
       end
     end

--- a/engines/bops_api/config/routes.rb
+++ b/engines/bops_api/config/routes.rb
@@ -34,6 +34,7 @@ BopsApi::Engine.routes.draw do
           get :search, on: :collection
           resource :documents, only: [:show]
           get "comments/public", to: "comments_public#index"
+          get "comments/specialist", to: "comments_specialist#index"
         end
       end
     end

--- a/engines/bops_api/schemas/odp/v0.7.3/comments_public.json
+++ b/engines/bops_api/schemas/odp/v0.7.3/comments_public.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "pagination": {
+      "$ref": "#/definitions/PostSubmissionPagination"
+    },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "totalComments": {
+          "type": "integer"
+        },
+        "sentiment": {
+          "type": "object",
+          "properties": {
+            "supportive": {
+              "type": "integer"
+            },
+            "objection": {
+              "type": "integer"
+            },
+            "neutral": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "required": ["totalComments", "sentiment"]
+    },
+    "comments": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "sentiment": {
+              "enum": ["objection", "neutral", "supportive"],
+              "type": "string"
+            },
+            "comment": {
+              "type": "string"
+            },
+            "receivedAt": {
+              "format": "datetime",
+              "type": ["string", "null"]
+            }
+          },
+          "required": ["id", "sentiment", "comment", "receivedAt"]
+        }
+      ]
+    }
+  },
+  "required": ["pagination", "summary", "comments"]
+}

--- a/engines/bops_api/schemas/odp/v0.7.3/comments_specialist.json
+++ b/engines/bops_api/schemas/odp/v0.7.3/comments_specialist.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "pagination": {
+      "$ref": "#/definitions/PostSubmissionPagination"
+    },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "totalComments": {
+          "type": "integer"
+        },
+        "totalConsulted": {
+          "type": "integer"
+        },
+        "sentiment": {
+          "type": "object",
+          "properties": {
+            "supportive": {
+              "type": "integer"
+            },
+            "objection": {
+              "type": "integer"
+            },
+            "neutral": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "required": ["totalComments", "totalConsulted", "sentiment"]
+    },
+    "comments": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "sentiment": {
+              "enum": ["objection", "neutral", "approved"],
+              "type": "string"
+            },
+            "comment": {
+              "type": "string"
+            },
+            "receivedAt": {
+              "format": "datetime",
+              "type": ["string", "null"]
+            }
+          },
+          "required": ["id", "sentiment", "comment", "receivedAt"]
+        }
+      ]
+    }
+  },
+  "required": ["pagination", "summary", "comments"]
+}

--- a/engines/bops_api/schemas/odp/v0.7.3/shared/definitions.json
+++ b/engines/bops_api/schemas/odp/v0.7.3/shared/definitions.json
@@ -15,10 +15,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "value",
-            "description"
-          ]
+          "required": ["value", "description"]
         },
         "reference": {
           "type": "string"
@@ -106,10 +103,7 @@
               }
             }
           },
-          "required": [
-            "startDate",
-            "endDate"
-          ]
+          "required": ["startDate", "endDate"]
         },
         "pressNotice": {
           "anyOf": [
@@ -127,11 +121,7 @@
                   "type": ["string", "null"]
                 }
               },
-              "required": [
-                "required",
-                "reason",
-                "publishedAt"
-              ]
+              "required": ["required", "reason", "publishedAt"]
             },
             {
               "type": "null"
@@ -150,6 +140,25 @@
         "status",
         "decision"
       ]
+    },
+    "PostSubmissionPagination": {
+      "$id": "#PostSubmissionPagination",
+      "type": "object",
+      "properties": {
+        "resultsPerPage": {
+          "type": "integer"
+        },
+        "currentPage": {
+          "type": "integer"
+        },
+        "totalPages": {
+          "type": "integer"
+        },
+        "totalItems": {
+          "type": "integer"
+        }
+      },
+      "required": ["resultsPerPage", "currentPage", "totalPages", "totalItems"]
     }
   }
 }

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.3/public/comments_public.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.3/public/comments_public.json
@@ -1,0 +1,42 @@
+{
+  "pagination": {
+    "resultsPerPage": 10,
+    "currentPage": 1,
+    "totalPages": 1,
+    "totalItems": 4
+  },
+  "summary": {
+    "totalComments": 4,
+    "sentiment": {
+      "supportive": 4,
+      "objection": 0,
+      "neutral": 0
+    }
+  },
+  "comments": [
+    {
+      "id": 1,
+      "sentiment": "supportive",
+      "comment": "Qui eos impedit. In nostrum nam. Qui odit non.",
+      "receivedAt": "2025-03-13T10:49:10Z"
+    },
+    {
+      "id": 2,
+      "sentiment": "supportive",
+      "comment": "Etiam porta sem malesuada magna mollis euismod.",
+      "receivedAt": "2025-03-13T10:49:22Z"
+    },
+    {
+      "id": 3,
+      "sentiment": "supportive",
+      "comment": "Cras mattis consectetur purus sit amet fermentum.",
+      "receivedAt": "2025-03-13T10:49:24Z"
+    },
+    {
+      "id": 4,
+      "sentiment": "supportive",
+      "comment": "Nullam id dolor id nibh ultricies vehicula ut id elit.",
+      "receivedAt": "2025-03-13T10:49:25Z"
+    }
+  ]
+}

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.3/public/comments_specialist.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.3/public/comments_specialist.json
@@ -1,0 +1,43 @@
+{
+  "pagination": {
+    "resultsPerPage": 10,
+    "currentPage": 1,
+    "totalPages": 1,
+    "totalItems": 4
+  },
+  "summary": {
+    "totalComments": 4,
+    "sentiment": {
+      "supportive": 4,
+      "objection": 0,
+      "neutral": 0
+    },
+    "totalConsulted": 4
+  },
+  "comments": [
+    {
+      "id": 1,
+      "sentiment": "supportive",
+      "comment": "Qui eos impedit. In nostrum nam. Qui odit non.",
+      "receivedAt": "2025-03-13T10:49:10Z"
+    },
+    {
+      "id": 2,
+      "sentiment": "supportive",
+      "comment": "Etiam porta sem malesuada magna mollis euismod.",
+      "receivedAt": "2025-03-13T10:49:22Z"
+    },
+    {
+      "id": 3,
+      "sentiment": "supportive",
+      "comment": "Cras mattis consectetur purus sit amet fermentum.",
+      "receivedAt": "2025-03-13T10:49:24Z"
+    },
+    {
+      "id": 4,
+      "sentiment": "supportive",
+      "comment": "Nullam id dolor id nibh ultricies vehicula ut id elit.",
+      "receivedAt": "2025-03-13T10:49:25Z"
+    }
+  ]
+}

--- a/engines/bops_api/spec/requests/v2/public/comments_public_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/comments_public_spec.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "BOPS public API Public comments" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:application_type) { create(:application_type, :householder) }
+
+  let(:planning_application) { create(:planning_application, :published, local_authority:, application_type:) }
+
+  before do
+    50.times do
+      neighbour = create(:neighbour, consultation: planning_application.consultation)
+      create(:neighbour_response, neighbour: neighbour)
+    end
+  end
+
+  path "/api/v2/public/planning_applications/{reference}/comments/public" do
+    get "Retrieves comments for a planning application" do
+      tags "Planning applications"
+      produces "application/json"
+
+      parameter name: :reference, in: :path, schema: {
+        type: :string,
+        description: "The planning application reference"
+      }
+
+      parameter name: :sortBy, in: :query, schema: {
+        type: :string,
+        enum: ["id", "receivedAt"],
+        default: "receivedAt",
+        description: "The sort type for the comments"
+      }, required: false
+
+      parameter name: :orderBy, in: :query, schema: {
+        type: :string,
+        enum: ["asc", "desc"],
+        default: "desc",
+        description: "The order for the comments"
+      }, required: false
+
+      parameter name: :resultsPerPage, in: :query, schema: {
+         type: :integer,
+         default: 10,
+         description: "Max result for page"
+       }, required: false
+
+      parameter name: :page, in: :query, schema: {
+         type: :integer,
+         default: 1
+       }, required: false
+
+      parameter name: :query, in: :query, schema: {
+        type: :string,
+        description: "Search by redacted comment content"
+      }, required: false
+
+      def validate_pagination(data, results_per_page:, current_page:, total_items:)
+        expect(data["pagination"]["resultsPerPage"]).to eq(results_per_page)
+        expect(data["pagination"]["currentPage"]).to eq(current_page)
+        expect(data["pagination"]["totalPages"]).to eq((total_items.to_f / results_per_page).ceil)
+        expect(data["pagination"]["totalItems"]).to eq(total_items)
+      end
+
+      def validate_comment_summary(data)
+        expect(data["summary"]["totalComments"]).to eq(50)
+        expect(data["summary"]["sentiment"]["supportive"]).to eq(50)
+        expect(data["summary"]["sentiment"]["objection"]).to eq(0)
+        expect(data["summary"]["sentiment"]["neutral"]).to eq(0)
+      end
+
+      def validate_comments(data, count:, total_items:)
+        expect(data["comments"].count).to eq(count)
+        data["comments"].each do |comment|
+          expect(comment["id"]).to be_a(Integer)
+          expect(comment["sentiment"]).to be_in(["supportive", "objection", "neutral"])
+          expect(comment["comment"]).to include("*****")
+          expect { DateTime.iso8601(comment["receivedAt"]) }.not_to raise_error
+        end
+      end
+
+      response "200", "returns a planning application's public comments given a reference" do
+        example "application/json", :default, example_fixture("public/comments_public.json")
+        schema "$ref" => "#/components/schemas/CommentsPublicResponse"
+
+        let(:reference) { planning_application.reference }
+
+        run_test! do |response|
+           data = JSON.parse(response.body)
+
+            # pagination
+            validate_pagination(data, results_per_page: BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::PostsubmissionPagination::DEFAULT_PAGE, total_items: 50)
+
+            # comment summary
+            validate_comment_summary(data)
+
+            # comments
+            validate_comments(data, count: 10, total_items: 50)
+        end
+      end
+
+      response "200", "returns planning application's public comments paginated given a page and resultsPerPage param" do
+        let(:reference) { planning_application.reference }
+        let(:page) { 2 }
+        let(:resultsPerPage) { 2 }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+
+          # pagination
+          validate_pagination(data, results_per_page: 2, current_page: 2, total_items: 50)
+
+          # comment summary
+          validate_comment_summary(data)
+
+          # comments
+          validate_comments(data, count: 2, total_items: 50)
+        end
+      end
+
+      response "200", "returns a planning application's public comments filtering by query" do
+        before do
+          create(:neighbour_response, response: "rude word not like the other comments", redacted_response: "***** not like the other comments", neighbour: create(:neighbour, consultation: planning_application.consultation))
+        end
+
+        let(:reference) { planning_application.reference }
+        let(:query) { "not like the other comments" }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+
+          # pagination
+          validate_pagination(data, results_per_page: BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::PostsubmissionPagination::DEFAULT_PAGE, total_items: 1)
+
+          # comment summary
+          expect(data["summary"]["totalComments"]).to eq(51)
+          expect(data["summary"]["sentiment"]["supportive"]).to eq(51)
+          expect(data["summary"]["sentiment"]["objection"]).to eq(0)
+          expect(data["summary"]["sentiment"]["neutral"]).to eq(0)
+
+          # comments
+          validate_comments(data, count: 1, total_items: 1)
+          expect(data["comments"].first["comment"]).to include("***** not like the other comments")
+        end
+      end
+
+      response "200", "returns a planning application's public comments filtering by sortBy and orderBy" do
+        let(:reference) { planning_application.reference }
+
+        context "when sortBy is not set and orderBy is not set " do
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            sorted_values = data["comments"].pluck("receivedAt")
+            expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
+          end
+        end
+
+        shared_examples "sortBy and orderBy validation" do |sort_by, order_by, field|
+          let(:sortBy) { sort_by }
+          let(:orderBy) { order_by }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            sorted_values = data["comments"].pluck(field)
+
+            expected_order = (order_by == "asc") ? sorted_values.sort : sorted_values.sort.reverse
+            expect(sorted_values).to eq(expected_order)
+          end
+        end
+
+        context "sortBy is id" do
+          it_behaves_like "sortBy and orderBy validation", "id", "asc", "id"
+          it_behaves_like "sortBy and orderBy validation", "id", "desc", "id"
+        end
+
+        context "sortBy is receivedAt" do
+          it_behaves_like "sortBy and orderBy validation", "receivedAt", "asc", "receivedAt"
+          it_behaves_like "sortBy and orderBy validation", "receivedAt", "desc", "receivedAt"
+        end
+
+        context "only sortBy is set" do
+          context "sortBy is receivedAt orderBy defaults to desc" do
+            let(:sortBy) { "receivedAt" }
+            run_test! do |response|
+              data = JSON.parse(response.body)
+              sorted_values = data["comments"].pluck("receivedAt")
+              expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
+            end
+          end
+
+          context "sortBy is id orderBy defaults to asc" do
+            let(:sortBy) { "id" }
+            run_test! do |response|
+              data = JSON.parse(response.body)
+              sorted_values = data["comments"].pluck("id")
+              expect(sorted_values).to eq(sorted_values.sort) # Ascending order
+            end
+          end
+        end
+
+        context "only orderBy is set" do
+          context "orderBy is asc sortBy defaults to receivedAt" do
+            let(:orderBy) { "asc" }
+            run_test! do |response|
+              data = JSON.parse(response.body)
+              sorted_values = data["comments"].pluck("receivedAt")
+              expect(sorted_values).to eq(sorted_values.sort) # Ascending order
+            end
+          end
+
+          context "orderBy is desc sortBy defaults to receivedAt" do
+            let(:orderBy) { "desc" }
+            run_test! do |response|
+              data = JSON.parse(response.body)
+              sorted_values = data["comments"].pluck("receivedAt")
+              expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
+            end
+          end
+        end
+      end
+
+      response "404", "does not return comments for unpublished planning applications" do
+        let(:reference) { planning_application.reference }
+
+        let(:planning_application) { create(:planning_application, local_authority:, application_type:) }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+
+          expect(data["error"]["message"]).to eq("Not Found")
+        end
+      end
+
+      it "validates successfully against the example comments_public json" do
+        resolved_schema = load_and_resolve_schema(name: "comments_public", version: BopsApi::Schemas::DEFAULT_ODP_VERSION)
+        schemer = JSONSchemer.schema(resolved_schema)
+        example_json = example_fixture("public/comments_public.json")
+
+        expect(schemer.valid?(example_json)).to eq(true)
+      end
+    end
+  end
+end

--- a/engines/bops_api/spec/requests/v2/public/comments_specialist_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/comments_specialist_spec.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "BOPS public API Specialist comments" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:planning_application) {
+    create(
+        :planning_application,
+      :published,
+      :in_assessment,
+      :with_boundary_geojson,
+      :planning_permission,
+      local_authority:
+      )
+  }
+
+  before do
+    25.times do
+      create(:consultee, :internal, :consulted, responses: build_list(:consultee_response, 1, :with_redaction), consultation: planning_application.consultation)
+    end
+
+    25.times do
+      create(:consultee, :external, :consulted, responses: build_list(:consultee_response, 1, :with_redaction), consultation: planning_application.consultation)
+    end
+
+    25.times do
+      create(:consultee, :internal, consultation: planning_application.consultation)
+    end
+
+    25.times do
+      create(:consultee, :external, consultation: planning_application.consultation)
+    end
+  end
+
+  path "/api/v2/public/planning_applications/{reference}/comments/specialist" do
+    get "Retrieves comments for a planning application" do
+      tags "Planning applications"
+      produces "application/json"
+
+      parameter name: :reference, in: :path, schema: {
+        type: :string,
+        description: "The planning application reference"
+      }
+
+      parameter name: :sortBy, in: :query, schema: {
+        type: :string,
+        enum: ["id", "receivedAt"],
+        default: "receivedAt",
+        description: "The sort type for the comments"
+      }, required: false
+
+      parameter name: :orderBy, in: :query, schema: {
+        type: :string,
+        enum: ["asc", "desc"],
+        default: "desc",
+        description: "The order for the comments"
+      }, required: false
+
+      parameter name: :resultsPerPage, in: :query, schema: {
+         type: :integer,
+         default: 10,
+         description: "Max result for page"
+       }, required: false
+
+      parameter name: :page, in: :query, schema: {
+         type: :integer,
+         default: 1
+       }, required: false
+
+      parameter name: :query, in: :query, schema: {
+        type: :string,
+        description: "Search by redacted comment content"
+      }, required: false
+
+      def validate_pagination(data, results_per_page:, current_page:, total_items:)
+        expect(data["pagination"]["resultsPerPage"]).to eq(results_per_page)
+        expect(data["pagination"]["currentPage"]).to eq(current_page)
+        expect(data["pagination"]["totalPages"]).to eq((total_items.to_f / results_per_page).ceil)
+        expect(data["pagination"]["totalItems"]).to eq(total_items)
+      end
+
+      def validate_comment_summary(data)
+        expect(data["summary"]["totalComments"]).to eq(50)
+        expect(data["summary"]["totalConsulted"]).to eq(100)
+        expect(data["summary"]["sentiment"]["supportive"]).to eq(50)
+        expect(data["summary"]["sentiment"]["objection"]).to eq(0)
+        expect(data["summary"]["sentiment"]["neutral"]).to eq(0)
+      end
+
+      def validate_comments(data, count:, total_items:)
+        expect(data["comments"].count).to eq(count)
+        data["comments"].each do |comment|
+          expect(comment["id"]).to be_a(Integer)
+          expect(comment["sentiment"]).to be_in(["supportive", "objection", "neutral"])
+          expect(comment["comment"]).to include("*****")
+          expect { DateTime.iso8601(comment["receivedAt"]) }.not_to raise_error
+        end
+      end
+
+      response "200", "returns a planning application's specialist comments given a reference" do
+        example "application/json", :default, example_fixture("public/comments_specialist.json")
+        schema "$ref" => "#/components/schemas/CommentsSpecialistResponse"
+
+        let(:reference) { planning_application.reference }
+
+        run_test! do |response|
+           data = JSON.parse(response.body)
+
+            # pagination
+            validate_pagination(data, results_per_page: BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::PostsubmissionPagination::DEFAULT_PAGE, total_items: 50)
+
+            # comment summary
+            validate_comment_summary(data)
+
+            # comments
+            validate_comments(data, count: 10, total_items: 50)
+        end
+      end
+
+      response "200", "returns planning application's specialist comments paginated given a page and resultsPerPage param" do
+        let(:reference) { planning_application.reference }
+        let(:page) { 2 }
+        let(:resultsPerPage) { 2 }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+
+          # pagination
+          validate_pagination(data, results_per_page: 2, current_page: 2, total_items: 50)
+
+          # comment summary
+          validate_comment_summary(data)
+
+          # comments
+          validate_comments(data, count: 2, total_items: 50)
+        end
+      end
+
+      response "200", "returns a planning application's specialist comments filtering by query" do
+        before do
+          create(:consultee, :external, :consulted, responses: build_list(:consultee_response, 1, :with_redaction, response: "rude word not like the other comments", redacted_response: "***** not like the other comments"), consultation: planning_application.consultation)
+        end
+
+        let(:reference) { planning_application.reference }
+        let(:query) { "not like the other comments" }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+
+          # pagination
+          validate_pagination(data, results_per_page: BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::PostsubmissionPagination::DEFAULT_PAGE, total_items: 1)
+
+          # comment summary
+          expect(data["summary"]["totalComments"]).to eq(51)
+          expect(data["summary"]["sentiment"]["supportive"]).to eq(51)
+          expect(data["summary"]["sentiment"]["objection"]).to eq(0)
+          expect(data["summary"]["sentiment"]["neutral"]).to eq(0)
+
+          # comments
+          validate_comments(data, count: 1, total_items: 1)
+          expect(data["comments"].first["comment"]).to include("***** not like the other comments")
+        end
+      end
+
+      response "200", "returns a planning application's specialist comments filtering by sortBy and orderBy" do
+        let(:reference) { planning_application.reference }
+
+        context "when sortBy is not set and orderBy is not set " do
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            sorted_values = data["comments"].pluck("receivedAt")
+            expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
+          end
+        end
+
+        shared_examples "sortBy and orderBy validation" do |sort_by, order_by, field|
+          let(:sortBy) { sort_by }
+          let(:orderBy) { order_by }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            sorted_values = data["comments"].pluck(field)
+
+            expected_order = (order_by == "asc") ? sorted_values.sort : sorted_values.sort.reverse
+            expect(sorted_values).to eq(expected_order)
+          end
+        end
+
+        context "sortBy is id" do
+          it_behaves_like "sortBy and orderBy validation", "id", "asc", "id"
+          it_behaves_like "sortBy and orderBy validation", "id", "desc", "id"
+        end
+
+        context "sortBy is receivedAt" do
+          it_behaves_like "sortBy and orderBy validation", "receivedAt", "asc", "receivedAt"
+          it_behaves_like "sortBy and orderBy validation", "receivedAt", "desc", "receivedAt"
+        end
+
+        context "only sortBy is set" do
+          context "sortBy is receivedAt orderBy defaults to desc" do
+            let(:sortBy) { "receivedAt" }
+            run_test! do |response|
+              data = JSON.parse(response.body)
+              sorted_values = data["comments"].pluck("receivedAt")
+              expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
+            end
+          end
+
+          context "sortBy is id orderBy defaults to asc" do
+            let(:sortBy) { "id" }
+            run_test! do |response|
+              data = JSON.parse(response.body)
+              sorted_values = data["comments"].pluck("id")
+              expect(sorted_values).to eq(sorted_values.sort) # Ascending order
+            end
+          end
+        end
+
+        context "only orderBy is set" do
+          context "orderBy is asc sortBy defaults to receivedAt" do
+            let(:orderBy) { "asc" }
+            run_test! do |response|
+              data = JSON.parse(response.body)
+              sorted_values = data["comments"].pluck("receivedAt")
+              expect(sorted_values).to eq(sorted_values.sort) # Ascending order
+            end
+          end
+
+          context "orderBy is desc sortBy defaults to receivedAt" do
+            let(:orderBy) { "desc" }
+            run_test! do |response|
+              data = JSON.parse(response.body)
+              sorted_values = data["comments"].pluck("receivedAt")
+              expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
+            end
+          end
+        end
+      end
+
+      response "404", "does not return comments for unpublished planning applications" do
+        let(:reference) { planning_application.reference }
+
+        let(:planning_application) {
+          create(
+              :planning_application,
+            :in_assessment,
+            :with_boundary_geojson,
+            :planning_permission,
+            local_authority:
+            )
+        }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+
+          expect(data["error"]["message"]).to eq("Not Found")
+        end
+      end
+
+      it "validates successfully against the example comments_specialist json" do
+        resolved_schema = load_and_resolve_schema(name: "comments_specialist", version: BopsApi::Schemas::DEFAULT_ODP_VERSION)
+        schemer = JSONSchemer.schema(resolved_schema)
+        example_json = example_fixture("public/comments_specialist.json")
+
+        expect(schemer.valid?(example_json)).to eq(true)
+      end
+    end
+  end
+end

--- a/engines/bops_api/spec/services/comments_public_service_spec.rb
+++ b/engines/bops_api/spec/services/comments_public_service_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BopsApi::CommentsPublicService, type: :service do
+  let!(:consultation) { create(:consultation, :started) }
+  let!(:neighbour) { create(:neighbour, source: "sent_comment", consultation:) }
+  let!(:neighbour_responses) { create_list(:neighbour_response, 50, neighbour:) }
+
+  let(:scope) { NeighbourResponse.all }
+  let(:params) { {} } # Default empty params
+  let(:service) { described_class.new(scope, params) }
+
+  describe "#call" do
+    context "when no parameters are provided" do
+      it "returns all records with default sorting and pagination" do
+        allow_any_instance_of(BopsApi::PostsubmissionPagination).to receive(:call).and_return([nil, scope])
+
+        _, result = service.call
+
+        expect(result).to eq(scope)
+      end
+    end
+
+    context "when a query parameter is provided" do
+      let(:params) { {query: "supportive"} }
+
+      it "filters the scope by the query" do
+        filtered_scope = scope.where("redacted_response ILIKE ?", "%supportive%")
+        allow(scope).to receive(:where).with("redacted_response ILIKE ?", "%supportive%").and_return(filtered_scope)
+        allow_any_instance_of(BopsApi::PostsubmissionPagination).to receive(:call).and_return([nil, filtered_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(filtered_scope)
+      end
+    end
+
+    context "sortBy and orderBy" do
+      context "when sortBy and orderBy parameters are provided" do
+        let(:params) { {sortBy: "id", orderBy: "desc"} }
+
+        it "sorts the scope by the specified field and order" do
+          sorted_scope = scope.order("neighbour_responses.id desc")
+          allow(scope).to receive(:order).with("neighbour_responses.id desc").and_return(sorted_scope)
+          allow_any_instance_of(BopsApi::PostsubmissionPagination).to receive(:call).and_return([nil, sorted_scope])
+
+          _, result = service.call
+
+          expect(result).to eq(sorted_scope)
+        end
+      end
+
+      context "when sortBy is provided" do
+        let(:params) { {sortBy: "id", orderBy: "asc"} }
+
+        it "sorts the scope by the specified field and order" do
+          sorted_scope = scope.order("neighbour_responses.id asc")
+          allow(scope).to receive(:order).with("neighbour_responses.id asc").and_return(sorted_scope)
+          allow_any_instance_of(BopsApi::PostsubmissionPagination).to receive(:call).and_return([nil, sorted_scope])
+
+          _, result = service.call
+
+          expect(result).to eq(sorted_scope)
+        end
+      end
+
+      context "when orderBy is provided" do
+        let(:params) { {orderBy: "asc"} }
+
+        it "sorts the scope by the specified field and order" do
+          sorted_scope = scope.order("received_at asc")
+          allow(scope).to receive(:order).with("received_at asc").and_return(sorted_scope)
+          allow_any_instance_of(BopsApi::PostsubmissionPagination).to receive(:call).and_return([nil, sorted_scope])
+
+          _, result = service.call
+
+          expect(result).to eq(sorted_scope)
+        end
+      end
+    end
+
+    context "when invalid sortBy is provided" do
+      let(:params) { {sortBy: "invalidField"} }
+
+      it "raises an ArgumentError" do
+        expect { service.call }.to raise_error(ArgumentError, /Invalid sortBy field/)
+      end
+    end
+
+    context "when invalid orderBy is provided" do
+      let(:params) { {orderBy: "invalidOrder"} }
+
+      it "raises an ArgumentError" do
+        expect { service.call }.to raise_error(ArgumentError, /Invalid orderBy value/)
+      end
+    end
+
+    context "when pagination is applied" do
+      it "calls the PostsubmissionPagination service" do
+        paginated_scope = double("paginated_scope")
+        allow_any_instance_of(BopsApi::PostsubmissionPagination).to receive(:call).and_return([nil, paginated_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(paginated_scope)
+      end
+    end
+  end
+end

--- a/engines/bops_api/spec/services/comments_specialist_service_spec.rb
+++ b/engines/bops_api/spec/services/comments_specialist_service_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BopsApi::CommentsSpecialistService, type: :service do
+  let!(:consultation) { create(:consultation, :started) }
+  let!(:consultee1) { create(:consultee, :internal, :consulted, :with_response, consultation:) }
+  let!(:consultee2) { create(:consultee, :external, :consulted, :with_response, consultation:) }
+
+  let(:scope) { Consultee::Response.all }
+  let(:params) { {} } # Default empty params
+  let(:service) { described_class.new(scope, params) }
+
+  describe "#call" do
+    context "when no parameters are provided" do
+      it "returns all records with default sorting and pagination" do
+        allow_any_instance_of(BopsApi::PostsubmissionPagination).to receive(:call).and_return([nil, scope])
+
+        _, result = service.call
+
+        expect(result).to eq(scope)
+      end
+    end
+
+    context "when a query parameter is provided" do
+      let(:params) { {query: "supportive"} }
+
+      it "filters the scope by the query" do
+        filtered_scope = scope.where("redacted_response ILIKE ?", "%supportive%")
+        allow(scope).to receive(:where).with("redacted_response ILIKE ?", "%supportive%").and_return(filtered_scope)
+        allow_any_instance_of(BopsApi::PostsubmissionPagination).to receive(:call).and_return([nil, filtered_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(filtered_scope)
+      end
+    end
+
+    context "sortBy and orderBy" do
+      context "when sortBy and orderBy parameters are provided" do
+        let(:params) { {sortBy: "id", orderBy: "desc"} }
+
+        it "sorts the scope by the specified field and order" do
+          sorted_scope = scope.order("consultee_responses.id desc")
+          allow(scope).to receive(:order).with("consultee_responses.id desc").and_return(sorted_scope)
+          allow_any_instance_of(BopsApi::PostsubmissionPagination).to receive(:call).and_return([nil, sorted_scope])
+
+          _, result = service.call
+
+          expect(result).to eq(sorted_scope)
+        end
+      end
+
+      context "when sortBy is provided" do
+        let(:params) { {sortBy: "id", orderBy: "asc"} }
+
+        it "sorts the scope by the specified field and order" do
+          sorted_scope = scope.order("consultee_responses.id asc")
+          allow(scope).to receive(:order).with("consultee_responses.id asc").and_return(sorted_scope)
+          allow_any_instance_of(BopsApi::PostsubmissionPagination).to receive(:call).and_return([nil, sorted_scope])
+
+          _, result = service.call
+
+          expect(result).to eq(sorted_scope)
+        end
+      end
+
+      context "when orderBy is provided" do
+        let(:params) { {orderBy: "asc"} }
+
+        it "sorts the scope by the specified field and order" do
+          sorted_scope = scope.order("received_at asc")
+          allow(scope).to receive(:order).with("received_at asc").and_return(sorted_scope)
+          allow_any_instance_of(BopsApi::PostsubmissionPagination).to receive(:call).and_return([nil, sorted_scope])
+
+          _, result = service.call
+
+          expect(result).to eq(sorted_scope)
+        end
+      end
+    end
+
+    context "when invalid sortBy is provided" do
+      let(:params) { {sortBy: "invalidField"} }
+
+      it "raises an ArgumentError" do
+        expect { service.call }.to raise_error(ArgumentError, /Invalid sortBy field/)
+      end
+    end
+
+    context "when invalid orderBy is provided" do
+      let(:params) { {orderBy: "invalidOrder"} }
+
+      it "raises an ArgumentError" do
+        expect { service.call }.to raise_error(ArgumentError, /Invalid orderBy value/)
+      end
+    end
+
+    context "when pagination is applied" do
+      it "calls the PostsubmissionPagination service" do
+        paginated_scope = double("paginated_scope")
+        allow_any_instance_of(BopsApi::PostsubmissionPagination).to receive(:call).and_return([nil, paginated_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(paginated_scope)
+      end
+    end
+  end
+end

--- a/engines/bops_api/spec/services/postsubmission_pagination_spec.rb
+++ b/engines/bops_api/spec/services/postsubmission_pagination_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BopsApi::PostsubmissionPagination, type: :service do
+  let!(:consultation) { create(:consultation, :started) }
+  let!(:neighbour) { create(:neighbour, source: "sent_comment", consultation:) }
+  let!(:neighbour_responses) { create_list(:neighbour_response, 50, neighbour:) }
+
+  let(:scope) { NeighbourResponse.all }
+  let(:params) { {} } # Default empty params
+  let(:service) { described_class.new(scope: scope, params: params) }
+
+  describe "#call" do
+    context "when no pagination parameters are provided" do
+      it "defaults to the first page and default results per page" do
+        pagy, paginated_scope = service.call
+
+        expect(pagy.page).to eq(BopsApi::PostsubmissionPagination::DEFAULT_PAGE)
+        expect(pagy.limit).to eq(BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS)
+        expect(paginated_scope.to_a).to eq(scope.limit(BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS).to_a)
+      end
+    end
+
+    context "when valid pagination parameters are provided" do
+      let(:params) { {page: 2, resultsPerPage: 5} }
+
+      it "paginates the results correctly" do
+        pagy, paginated_scope = service.call
+
+        expect(pagy.page).to eq(2)
+        expect(pagy.limit).to eq(5)
+        expect(paginated_scope).to eq(scope.offset(5).limit(5))
+      end
+    end
+
+    context "when resultsPerPage exceeds the maximum limit" do
+      let(:params) { {resultsPerPage: 100} }
+
+      it "caps resultsPerPage to the maximum limit" do
+        pagy, paginated_scope = service.call
+
+        expect(pagy.limit).to eq(BopsApi::PostsubmissionPagination::MAXRESULTS_LIMIT)
+        expect(paginated_scope.to_a).to eq(scope.limit(50).to_a)
+      end
+    end
+
+    context "when invalid pagination parameters are provided" do
+      let(:params) { {page: -1, resultsPerPage: -5} }
+
+      it "defaults to the first page and default results per page" do
+        pagy, paginated_scope = service.call
+
+        expect(pagy.page).to eq(BopsApi::PostsubmissionPagination::DEFAULT_PAGE)
+        expect(pagy.limit).to eq(BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS)
+        expect(paginated_scope.to_a).to eq(scope.limit(BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS).to_a)
+      end
+    end
+
+    context "when resultsPerPage is zero" do
+      let(:params) { {resultsPerPage: 0} }
+
+      it "defaults to the default results per page" do
+        pagy, paginated_scope = service.call
+
+        expect(pagy.limit).to eq(BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS)
+        expect(paginated_scope.to_a).to eq(scope.limit(BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS).to_a)
+      end
+    end
+
+    context "when page is zero" do
+      let(:params) { {page: 0} }
+
+      it "defaults to the first page" do
+        pagy, paginated_scope = service.call
+
+        expect(pagy.page).to eq(BopsApi::PostsubmissionPagination::DEFAULT_PAGE)
+        expect(paginated_scope.to_a).to eq(scope.limit(BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS).to_a)
+      end
+    end
+
+    context "when the scope is empty" do
+      let(:scope) { NeighbourResponse.none }
+
+      it "returns an empty paginated scope" do
+        pagy, paginated_scope = service.call
+
+        expect(pagy.page).to eq(BopsApi::PostsubmissionPagination::DEFAULT_PAGE)
+        expect(pagy.limit).to eq(BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS)
+        expect(paginated_scope).to be_empty
+      end
+    end
+  end
+
+  describe "#results_per_page" do
+    it "returns the default results per page when no parameter is provided" do
+      expect(service.send(:results_per_page)).to eq(BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS)
+    end
+
+    it "returns the capped results per page when exceeding the maximum limit" do
+      params[:resultsPerPage] = 100
+      expect(service.send(:results_per_page)).to eq(BopsApi::PostsubmissionPagination::MAXRESULTS_LIMIT)
+    end
+
+    it "returns the default results per page when a negative value is provided" do
+      params[:resultsPerPage] = -5
+      expect(service.send(:results_per_page)).to eq(BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS)
+    end
+
+    it "returns the default results per page when a string is provided" do
+      params[:resultsPerPage] = "fifteen"
+      expect(service.send(:results_per_page)).to eq(BopsApi::PostsubmissionPagination::DEFAULT_MAXRESULTS)
+    end
+  end
+
+  describe "#page" do
+    it "returns the default page when no parameter is provided" do
+      expect(service.send(:page)).to eq(BopsApi::PostsubmissionPagination::DEFAULT_PAGE)
+    end
+
+    it "returns the default page when a negative value is provided" do
+      params[:page] = -1
+      expect(service.send(:page)).to eq(BopsApi::PostsubmissionPagination::DEFAULT_PAGE)
+    end
+
+    it "returns the default page when a string is provided" do
+      params[:page] = "one"
+      expect(service.send(:page)).to eq(BopsApi::PostsubmissionPagination::DEFAULT_PAGE)
+    end
+
+    it "returns the provided page when a valid value is provided" do
+      params[:page] = 3
+      expect(service.send(:page)).to eq(3)
+    end
+  end
+end

--- a/engines/bops_api/spec/swagger_helper.rb
+++ b/engines/bops_api/spec/swagger_helper.rb
@@ -18,6 +18,8 @@ RSpec.configure do |config|
   neighbour_responses_json = BopsApi::Schemas.find!("neighbourResponses", version:).value
   validation_requests_json = BopsApi::Schemas.find!("validationRequests", version:).value
   shared_definitions_json = BopsApi::Schemas.find!("shared/definitions", version:).value
+  comments_public_json = BopsApi::Schemas.find!("comments_public", version:).value
+  comments_specialist_json = BopsApi::Schemas.find!("comments_specialist", version:).value
 
   keys = %w[
     additionalProperties
@@ -47,6 +49,10 @@ RSpec.configure do |config|
   neighbour_responses = neighbour_responses_json.slice(*keys).deep_transform_values(&transformer)
 
   validation_requests = validation_requests_json.slice(*keys).deep_transform_values(&transformer)
+
+  comments_public = comments_public_json.slice(*keys).deep_transform_values(&transformer)
+
+  comments_specialist = comments_specialist_json.slice(*keys).deep_transform_values(&transformer)
 
   config.openapi_specs = {
     "v2/swagger_doc.yaml" => {
@@ -90,6 +96,10 @@ RSpec.configure do |config|
           NeighbourResponses: neighbour_responses,
 
           ValidationRequests: validation_requests,
+
+          CommentsPublicResponse: comments_public,
+
+          CommentsSpecialistResponse: comments_specialist,
 
           Healthcheck: {
             type: "object",

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -20888,6 +20888,23 @@ components:
       - determinedAt
       - status
       - decision
+    PostSubmissionPagination:
+      "$id": "#PostSubmissionPagination"
+      type: object
+      properties:
+        resultsPerPage:
+          type: integer
+        currentPage:
+          type: integer
+        totalPages:
+          type: integer
+        totalItems:
+          type: integer
+      required:
+      - resultsPerPage
+      - currentPage
+      - totalPages
+      - totalItems
   schemas:
     Submission:
       additionalProperties: false
@@ -21461,6 +21478,111 @@ components:
       - metadata
       - links
       - data
+      type: object
+    CommentsPublicResponse:
+      properties:
+        pagination:
+          "$ref": "#/components/definitions/PostSubmissionPagination"
+        summary:
+          type: object
+          properties:
+            totalComments:
+              type: integer
+            sentiment:
+              type: object
+              properties:
+                supportive:
+                  type: integer
+                objection:
+                  type: integer
+                neutral:
+                  type: integer
+          required:
+          - totalComments
+          - sentiment
+        comments:
+          type: array
+          items:
+          - type: object
+            properties:
+              id:
+                type: integer
+              sentiment:
+                enum:
+                - objection
+                - neutral
+                - supportive
+                type: string
+              comment:
+                type: string
+              receivedAt:
+                format: datetime
+                type:
+                - string
+                - 'null'
+            required:
+            - id
+            - sentiment
+            - comment
+            - receivedAt
+      required:
+      - pagination
+      - summary
+      - comments
+      type: object
+    CommentsSpecialistResponse:
+      properties:
+        pagination:
+          "$ref": "#/components/definitions/PostSubmissionPagination"
+        summary:
+          type: object
+          properties:
+            totalComments:
+              type: integer
+            totalConsulted:
+              type: integer
+            sentiment:
+              type: object
+              properties:
+                supportive:
+                  type: integer
+                objection:
+                  type: integer
+                neutral:
+                  type: integer
+          required:
+          - totalComments
+          - totalConsulted
+          - sentiment
+        comments:
+          type: array
+          items:
+          - type: object
+            properties:
+              id:
+                type: integer
+              sentiment:
+                enum:
+                - objection
+                - neutral
+                - approved
+                type: string
+              comment:
+                type: string
+              receivedAt:
+                format: datetime
+                type:
+                - string
+                - 'null'
+            required:
+            - id
+            - sentiment
+            - comment
+            - receivedAt
+      required:
+      - pagination
+      - summary
+      - comments
       type: object
     Healthcheck:
       type: object
@@ -34971,6 +35093,191 @@ paths:
                             country: ''
               schema:
                 "$ref": "#/components/schemas/Search"
+  "/api/v2/public/planning_applications/{reference}/comments/public":
+    get:
+      summary: Retrieves comments for a planning application
+      tags:
+      - Planning applications
+      parameters:
+      - name: reference
+        in: path
+        schema:
+          type: string
+          description: The planning application reference
+        required: true
+      - name: sortBy
+        in: query
+        schema:
+          type: string
+          enum:
+          - id
+          - receivedAt
+          default: receivedAt
+          description: The sort type for the comments
+        required: false
+      - name: orderBy
+        in: query
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: desc
+          description: The order for the comments
+        required: false
+      - name: resultsPerPage
+        in: query
+        schema:
+          type: integer
+          default: 10
+          description: Max result for page
+        required: false
+      - name: page
+        in: query
+        schema:
+          type: integer
+          default: 1
+        required: false
+      - name: query
+        in: query
+        schema:
+          type: string
+          description: Search by redacted comment content
+        required: false
+      responses:
+        '200':
+          description: returns a planning application's public comments filtering
+            by sortBy and orderBy
+          content:
+            application/json:
+              examples:
+                default:
+                  value:
+                    pagination:
+                      resultsPerPage: 10
+                      currentPage: 1
+                      totalPages: 1
+                      totalItems: 4
+                    summary:
+                      totalComments: 4
+                      sentiment:
+                        supportive: 4
+                        objection: 0
+                        neutral: 0
+                    comments:
+                    - id: 1
+                      sentiment: supportive
+                      comment: Qui eos impedit. In nostrum nam. Qui odit non.
+                      receivedAt: '2025-03-13T10:49:10Z'
+                    - id: 2
+                      sentiment: supportive
+                      comment: Etiam porta sem malesuada magna mollis euismod.
+                      receivedAt: '2025-03-13T10:49:22Z'
+                    - id: 3
+                      sentiment: supportive
+                      comment: Cras mattis consectetur purus sit amet fermentum.
+                      receivedAt: '2025-03-13T10:49:24Z'
+                    - id: 4
+                      sentiment: supportive
+                      comment: Nullam id dolor id nibh ultricies vehicula ut id elit.
+                      receivedAt: '2025-03-13T10:49:25Z'
+              schema:
+                "$ref": "#/components/schemas/CommentsPublicResponse"
+        '404':
+          description: does not return comments for unpublished planning applications
+  "/api/v2/public/planning_applications/{reference}/comments/specialist":
+    get:
+      summary: Retrieves comments for a planning application
+      tags:
+      - Planning applications
+      parameters:
+      - name: reference
+        in: path
+        schema:
+          type: string
+          description: The planning application reference
+        required: true
+      - name: sortBy
+        in: query
+        schema:
+          type: string
+          enum:
+          - id
+          - receivedAt
+          default: receivedAt
+          description: The sort type for the comments
+        required: false
+      - name: orderBy
+        in: query
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: desc
+          description: The order for the comments
+        required: false
+      - name: resultsPerPage
+        in: query
+        schema:
+          type: integer
+          default: 10
+          description: Max result for page
+        required: false
+      - name: page
+        in: query
+        schema:
+          type: integer
+          default: 1
+        required: false
+      - name: query
+        in: query
+        schema:
+          type: string
+          description: Search by redacted comment content
+        required: false
+      responses:
+        '200':
+          description: returns a planning application's specialist comments filtering
+            by sortBy and orderBy
+          content:
+            application/json:
+              examples:
+                default:
+                  value:
+                    pagination:
+                      resultsPerPage: 10
+                      currentPage: 1
+                      totalPages: 1
+                      totalItems: 4
+                    summary:
+                      totalComments: 4
+                      sentiment:
+                        supportive: 4
+                        objection: 0
+                        neutral: 0
+                      totalConsulted: 4
+                    comments:
+                    - id: 1
+                      sentiment: supportive
+                      comment: Qui eos impedit. In nostrum nam. Qui odit non.
+                      receivedAt: '2025-03-13T10:49:10Z'
+                    - id: 2
+                      sentiment: supportive
+                      comment: Etiam porta sem malesuada magna mollis euismod.
+                      receivedAt: '2025-03-13T10:49:22Z'
+                    - id: 3
+                      sentiment: supportive
+                      comment: Cras mattis consectetur purus sit amet fermentum.
+                      receivedAt: '2025-03-13T10:49:24Z'
+                    - id: 4
+                      sentiment: supportive
+                      comment: Nullam id dolor id nibh ultricies vehicula ut id elit.
+                      receivedAt: '2025-03-13T10:49:25Z'
+              schema:
+                "$ref": "#/components/schemas/CommentsSpecialistResponse"
+        '404':
+          description: does not return comments for unpublished planning applications
   "/api/v2/public/planning_applications/{reference}/documents":
     get:
       summary: Retrieves documents for a planning application

--- a/spec/factories/consultee_response.rb
+++ b/spec/factories/consultee_response.rb
@@ -6,5 +6,11 @@ FactoryBot.define do
     summary_tag { "approved" }
     response { Faker::Lorem.paragraph }
     received_at { Time.current }
+
+    trait :with_redaction do
+      redacted_by { association :user }
+      response { "I like it rude word" }
+      redacted_response { "I like it *****" }
+    end
   end
 end


### PR DESCRIPTION
# Acceptance Criteria:



## public endpoint:


- [x] the public endpoint is found at `/api/v2/public/planning_applications/{reference}/comments/public` and is functional
  - [x] if the application is not published an error is shown
  - [x] if there are no comments, no comments are shown
  - if there are comments: 
    - [x] comments shown for that planning application only
    - [x] comments are paginated (see search & filtering criteria)
    - [x] only comments which have been redacted are shown
    - comments include:
      - [x] id
      - [x] sentiment
      - [x] comment (redacted)
      - [x] receivedAt in ISO8601 utc format (with the `format_postsubmission_datetime` helper)


## pagination:

- [x] results are paginated by PostsubmissionPagination
- [x] when passing `resultsPerPage` the number of results shown on the page changes 
  - [x] if the number passed is greater than 50 resultsPerPage is set to 50
- [x] there are tests for the PostSubmissionPagination service

## search & filtering aka `CommentsPublicService`

- [x] filtering is controlled by CommentsPublicService
- [x] when passing `query` the `redacted_response` field is searched and results returned
- `sortBy` field only accepts
  - [x] receivedAt 
  - [x] id
- `orderBy` field only accepts
  - [x] asc
  - [x] desc
- When no orderBy is passed with sortBy
  - [x] sortBy: receivedAt defaults to orderBy: desc
  - [x] sortBy: id defaults to orderBy: desc
- [x] there are tests for the `CommentsPublicService` covering each of these requirements
- [x] each endpoint is documented in swagger along with the functionality of the params



## additional returned results:

- [x] returns summary information matching [this specification](https://github.com/theopensystemslab/digital-planning-data-schemas/blob/main/types/schemas/postSubmissionApplication/data/CommentSummary.ts#L28) for `PublicCommentSummary`



# specialist endpoint:

## specialist endpoint:


- [x] the specialist endpoint is found at `/api/v2/public/planning_applications/{reference}/comments/specialist` and is functional
  - [x] if the application is not published an error is shown
  - [x] if there are no comments, no comments are shown
  - if there are comments: 
    - [x] comments shown for that planning application only
    - [x] comments are paginated (see search & filtering criteria)
    - [x] only comments which have been redacted are shown
   - comments include
      - [x] id
      - [x] sentiment
      - [x] comment (redacted)
      - [x] receivedAt in ISO8601 utc format (with the `format_postsubmission_datetime` helper)
 

## pagination:


- [x] results are paginated by `PostsubmissionPagination`
- [x] when passing resultsPerPage the number of results shown on the page changes 
  - [x] if the number passed is greater than 50 resultsPerPage is set to 50
- [x] there are tests for the `PostSubmissionPagination` service

## search & filtering aka `CommentsSpecialistService`: 

- [x] filtering is controlled by `CommentsSpecialistService`
- [x] when passing query the `redacted_response` field is searched and results returned
- sortBy field only accepts
  - [x] receivedAt 
  - [x] id
- [x] orderBy field only accepts
  - [x] asc
  - [x] desc
- When no orderBy is passed with sortBy
  - [x] sortBy: receivedAt defaults to orderBy: desc
  - [x] sortBy: id defaults to orderBy: desc
- [x] there are tests for the CommentsSpecialistService covering each of these requirements
- [x] each endpoint is documented in swagger along with the functionality of the params
 

## additional returned results:


- [x] returns summary information matching [this specification](https://github.com/theopensystemslab/digital-planning-data-schemas/blob/main/types/schemas/postSubmissionApplication/data/CommentSummary.ts#L28) for SpecialistCommentSummary